### PR TITLE
include angular using protocol-relative URL

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -122,7 +122,7 @@
 
 		<toasty></toasty>
 
-		<script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
+		<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
 	    <script src="../dist/angular-toasty.js"></script>
 
 	    <!-- Demo Script -->


### PR DESCRIPTION
When viewing page using https, some browsers block http content